### PR TITLE
Fix bun install in Vercel pipeline

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "installCommand": "bun install",
+  "buildCommand": "bun run build",
+  "outputDirectory": "dist"
+}


### PR DESCRIPTION
## Summary
- configure Vercel not to use `--frozen-lockfile` so bun can install

## Testing
- `npm run lint` *(fails: 3 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6884d6d61cec832a8b4bc2000efe3ae7